### PR TITLE
Store as args

### DIFF
--- a/benches/hnsw.rs
+++ b/benches/hnsw.rs
@@ -13,40 +13,51 @@ use rand::SeedableRng;
 fn hnsw_db(c: &mut Criterion) {
     let mut group = c.benchmark_group("hnsw");
     for database_size in [1000, 10000, 100000] {
-        let vector_store = LazyMemoryStore::new();
-        let graph_store = GraphMem::new();
-        let mut rng = AesRng::seed_from_u64(0_u64);
-        let mut initial_db = HawkSearcher::new(vector_store, graph_store, &mut rng);
+        let vector_store = &mut LazyMemoryStore::new();
+        let graph_store = &mut GraphMem::new();
+        let rng = &mut AesRng::seed_from_u64(0_u64);
+        let initial_db = &HawkSearcher::new();
 
         let queries = (0..database_size)
-            .map(|raw_query| initial_db.vector_store.prepare_query(raw_query))
+            .map(|raw_query| vector_store.prepare_query(raw_query))
             .collect::<Vec<_>>();
 
         let runtime = tokio::runtime::Runtime::new().unwrap();
         // Insert the codes.
 
-        let full_db = runtime.block_on(async move {
+        runtime.block_on(async {
             for query in queries.iter() {
-                let neighbors = initial_db.search_to_insert(query).await;
-                assert!(!initial_db.is_match(&neighbors).await);
+                let neighbors = initial_db
+                    .search_to_insert(vector_store, graph_store, query)
+                    .await;
+                assert!(!initial_db.is_match(vector_store, &neighbors).await);
                 // Insert the new vector into the store.
-                let inserted = initial_db.vector_store.insert(query).await;
+                let inserted = vector_store.insert(query).await;
                 initial_db
-                    .insert_from_search_results(inserted, neighbors)
+                    .insert_from_search_results(vector_store, graph_store, rng, inserted, neighbors)
                     .await;
             }
-            initial_db
         });
         group.bench_function(BenchmarkId::new("hnsw-insertions", database_size), |b| {
             b.iter_batched_ref(
-                || full_db.clone(),
-                |my_db| {
+                || (vector_store.clone(), graph_store.clone(), rng.clone()),
+                |(vector_store, graph_store, rng)| {
                     runtime.block_on(async move {
                         let raw_query = database_size;
-                        let query = my_db.vector_store.prepare_query(raw_query);
-                        let neighbors = my_db.search_to_insert(&query).await;
-                        let inserted = my_db.vector_store.insert(&query).await;
-                        my_db.insert_from_search_results(inserted, neighbors).await;
+                        let query = vector_store.prepare_query(raw_query);
+                        let neighbors = initial_db
+                            .search_to_insert(vector_store, graph_store, &query)
+                            .await;
+                        let inserted = vector_store.insert(&query).await;
+                        initial_db
+                            .insert_from_search_results(
+                                vector_store,
+                                graph_store,
+                                rng,
+                                inserted,
+                                neighbors,
+                            )
+                            .await;
                     });
                 },
                 criterion::BatchSize::SmallInput,

--- a/src/hnsw_db/coroutine.rs
+++ b/src/hnsw_db/coroutine.rs
@@ -3,7 +3,6 @@ use crate::{
     hnsw_db::{FurthestQueue, HawkSearcher},
     GraphStore, Ref, VectorStore,
 };
-use aes_prng::AesRng;
 use std::fmt::Debug;
 use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
@@ -28,13 +27,12 @@ where
 {
     let (tx, rx) = mpsc::channel(1);
     tokio::spawn(async move {
-        let mut rng = AesRng::from_random_seed();
-        let hawk = HawkSearcher::new(
-            OpsCollector { ops: tx.clone() },
-            OpsCollector { ops: tx.clone() },
-            &mut rng,
-        );
-        let result = hawk.search_to_insert(&query).await;
+        let hawk = HawkSearcher::new();
+        let vector_store = &mut OpsCollector { ops: tx.clone() };
+        let graph_store = &mut OpsCollector { ops: tx.clone() };
+        let result = hawk
+            .search_to_insert(vector_store, graph_store, &query)
+            .await;
         tx.send(Op::SearchResult { query, result }).await.unwrap();
     });
     ReceiverStream::new(rx)


### PR DESCRIPTION
Proposing a different API style. It’s the same functionality with a different usage syntax.

Replace the builder style (`HawkSearcher::new`) with method arguments to pass state (`search(…, vector_store: &mut V, …)`).

Here, `HawkSearcher` basically becomes the same as `Params`.

_Choose this style **or** #25._
