### PR TITLE
Generalize conversion between graphs

### DIFF
--- a/src/hnsw_db/queue.rs
+++ b/src/hnsw_db/queue.rs
@@ -64,6 +64,7 @@ impl<Vector: Clone, Distance: Clone> FurthestQueue<Vector, Distance> {
         self.queue.truncate(k);
     }
 
+    // Assumes that distance map doesn't change the distance metric
     pub fn map<V>(
         self,
         vector_map: fn(Vector) -> V::VectorRef,

--- a/src/hnsw_db/queue.rs
+++ b/src/hnsw_db/queue.rs
@@ -24,7 +24,7 @@ impl<Vector: Clone, Distance: Clone> FurthestQueue<Vector, Distance> {
         FurthestQueue { queue }
     }
 
-    /// Insert the element `to` with distance `dist` into the queue, maitaining the ascending order.
+    /// Insert the element `to` with distance `dist` into the queue, maintaining the ascending order.
     ///
     /// Call the VectorStore to come up with the insertion index.
     pub async fn insert<V>(&mut self, store: &V, to: Vector, dist: Distance)
@@ -62,6 +62,23 @@ impl<Vector: Clone, Distance: Clone> FurthestQueue<Vector, Distance> {
 
     pub fn trim_to_k_nearest(&mut self, k: usize) {
         self.queue.truncate(k);
+    }
+
+    pub fn map<V>(
+        self,
+        vector_map: fn(Vector) -> V::VectorRef,
+        distance_map: fn(Distance) -> V::DistanceRef,
+    ) -> FurthestQueue<V::VectorRef, V::DistanceRef>
+    where
+        V: VectorStore,
+    {
+        let queue: Vec<(V::VectorRef, V::DistanceRef)> = self
+            .queue
+            .iter()
+            .cloned()
+            .map(|(v, d)| (vector_map(v), distance_map(d)))
+            .collect();
+        FurthestQueue::from_ascending_vec(queue)
     }
 }
 


### PR DESCRIPTION
Now we can convert between graphs with arbitrary associated types of their respective vector stores. 