### PR TITLE
Getters for graph conversion

### DIFF
--- a/src/examples/lazy_memory_store.rs
+++ b/src/examples/lazy_memory_store.rs
@@ -5,12 +5,12 @@ use crate::VectorStore;
 /// Example implementation of a vector store - Lazy variant.
 ///
 /// A distance is lazily represented in `DistanceRef` as a tuple of point IDs, and the actual distance is evaluated later in `less_than`.
-#[derive(Default, Clone, Debug)]
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
 pub struct LazyMemoryStore {
     points: Vec<Point>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 struct Point {
     /// Whatever encoding of a vector.
     data: u64,
@@ -19,7 +19,13 @@ struct Point {
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub struct PointId(usize);
+pub struct PointId(pub usize);
+
+impl PointId {
+    pub fn val(&self) -> usize {
+        self.0
+    }
+}
 
 impl LazyMemoryStore {
     pub fn new() -> Self {

--- a/src/graph_store/graph_mem.rs
+++ b/src/graph_store/graph_mem.rs
@@ -19,6 +19,16 @@ impl<V: VectorStore> GraphMem<V> {
         }
     }
 
+    pub fn from_precomputed(
+        entry_point: Option<EntryPoint<V::VectorRef>>,
+        layers: Vec<Layer<V>>,
+    ) -> Self {
+        GraphMem {
+            entry_point,
+            layers,
+        }
+    }
+
     pub fn get_layers(&self) -> Vec<Layer<V>> {
         self.layers.clone()
     }

--- a/src/graph_store/graph_mem.rs
+++ b/src/graph_store/graph_mem.rs
@@ -109,6 +109,10 @@ impl<V: VectorStore> Layer<V> {
         }
     }
 
+    pub fn from_links(links: HashMap<V::VectorRef, FurthestQueueV<V>>) -> Self {
+        Layer { links }
+    }
+
     fn get_links(&self, from: &V::VectorRef) -> Option<&FurthestQueueV<V>> {
         self.links.get(from)
     }

--- a/src/graph_store/graph_mem.rs
+++ b/src/graph_store/graph_mem.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use std::collections::HashMap;
 
-#[derive(Default, Clone)]
+#[derive(Default, Clone, PartialEq, Eq, Debug)]
 pub struct GraphMem<V: VectorStore> {
     entry_point: Option<EntryPoint<V::VectorRef>>,
     layers: Vec<Layer<V>>,
@@ -106,7 +106,7 @@ impl<V: VectorStore> GraphStore<V> for GraphMem<V> {
     }
 }
 
-#[derive(PartialEq, Eq, Default, Clone)]
+#[derive(PartialEq, Eq, Default, Clone, Debug)]
 pub struct Layer<V: VectorStore> {
     /// Map a base vector to its neighbors, including the distance base-neighbor.
     links: HashMap<V::VectorRef, FurthestQueueV<V>>,
@@ -133,5 +133,182 @@ impl<V: VectorStore> Layer<V> {
 
     pub fn get_links_map(&self) -> &HashMap<V::VectorRef, FurthestQueueV<V>> {
         &self.links
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use aes_prng::AesRng;
+    use rand::{RngCore, SeedableRng};
+    use serde::{Deserialize, Serialize};
+
+    use crate::{
+        examples::lazy_memory_store::{LazyMemoryStore, PointId},
+        hnsw_db::HawkSearcher,
+    };
+
+    use super::*;
+
+    #[derive(Default, Clone, Debug, PartialEq, Eq)]
+    pub struct TestStore {
+        points: HashMap<usize, Point>,
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq)]
+    struct Point {
+        /// Whatever encoding of a vector.
+        data: u64,
+        /// Distinguish between queries that are pending, and those that were ultimately accepted into the vector store.
+        is_persistent: bool,
+    }
+
+    #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct TestPointId(pub usize);
+
+    impl TestPointId {
+        pub fn val(&self) -> usize {
+            self.0
+        }
+    }
+
+    fn hamming_distance(a: u64, b: u64) -> u32 {
+        (a ^ b).count_ones()
+    }
+
+    impl VectorStore for TestStore {
+        type QueryRef = TestPointId; // Vector ID, pending insertion.
+        type VectorRef = TestPointId; // Vector ID, inserted.
+        type DistanceRef = u32; // Eager distance representation.
+
+        async fn insert(&mut self, query: &Self::QueryRef) -> Self::VectorRef {
+            // The query is now accepted in the store. It keeps the same ID.
+            self.points.get_mut(&query.val()).unwrap().is_persistent = true;
+            *query
+        }
+
+        async fn eval_distance(
+            &self,
+            query: &Self::QueryRef,
+            vector: &Self::VectorRef,
+        ) -> Self::DistanceRef {
+            // Hamming distance
+            let vector_0 = self.points[&query.val()].data;
+            let vector_1 = self.points[&vector.val()].data;
+            hamming_distance(vector_0, vector_1)
+        }
+
+        async fn is_match(&self, distance: &Self::DistanceRef) -> bool {
+            *distance == 0
+        }
+
+        async fn less_than(
+            &self,
+            distance1: &Self::DistanceRef,
+            distance2: &Self::DistanceRef,
+        ) -> bool {
+            *distance1 < *distance2
+        }
+    }
+
+    #[tokio::test]
+    async fn test_from_another_naive() {
+        let mut vector_store = LazyMemoryStore::new();
+        let mut graph_store = GraphMem::new();
+        let searcher = HawkSearcher::default();
+        let mut rng = AesRng::seed_from_u64(0_u64);
+
+        for raw_query in 0..10 {
+            let query = vector_store.prepare_query(raw_query);
+            let neighbors = searcher
+                .search_to_insert(&mut vector_store, &mut graph_store, &query)
+                .await;
+            let inserted = vector_store.insert(&query).await;
+            searcher
+                .insert_from_search_results(
+                    &mut vector_store,
+                    &mut graph_store,
+                    &mut rng,
+                    inserted,
+                    neighbors,
+                )
+                .await;
+        }
+
+        let equal_graph_store: GraphMem<LazyMemoryStore> =
+            GraphMem::from_another(graph_store.clone(), |v| v, |d| d);
+        assert_eq!(graph_store, equal_graph_store);
+
+        let different_graph_store: GraphMem<LazyMemoryStore> =
+            GraphMem::from_another(graph_store.clone(), |v| PointId(v.val() * 2), |d| d);
+        assert_ne!(graph_store, different_graph_store);
+    }
+
+    #[tokio::test]
+    async fn test_from_another() {
+        let mut vector_store = LazyMemoryStore::new();
+        let mut graph_store = GraphMem::new();
+        let searcher = HawkSearcher::default();
+        let mut rng = AesRng::seed_from_u64(0_u64);
+
+        let mut point_ids: HashMap<PointId, TestPointId> = HashMap::new();
+        let mut distances: HashMap<(PointId, PointId), u32> = HashMap::new();
+
+        for raw_query in 0..10 {
+            let query = vector_store.prepare_query(raw_query);
+            let neighbors = searcher
+                .search_to_insert(&mut vector_store, &mut graph_store, &query)
+                .await;
+            let inserted = vector_store.insert(&query).await;
+            searcher
+                .insert_from_search_results(
+                    &mut vector_store,
+                    &mut graph_store,
+                    &mut rng,
+                    inserted,
+                    neighbors,
+                )
+                .await;
+
+            point_ids.insert(query, TestPointId(rng.next_u64() as usize));
+            for future_query in 0..10_u64 {
+                distances.insert(
+                    (query, PointId(future_query as usize)),
+                    hamming_distance(raw_query, future_query),
+                );
+            }
+        }
+
+        let new_graph_store: GraphMem<TestStore> =
+            GraphMem::from_another(graph_store.clone(), |v| point_ids[&v], |d| distances[&d]);
+
+        let entry_point = graph_store.get_entry_point().await.unwrap();
+        let new_entry_point = new_graph_store.get_entry_point().await.unwrap();
+
+        // Check that entry points are correct
+        assert_eq!(entry_point.layer_count, new_entry_point.layer_count);
+        assert_eq!(
+            point_ids[&entry_point.vector_ref],
+            new_entry_point.vector_ref
+        );
+
+        let layers = graph_store.get_layers();
+        let new_layers = new_graph_store.get_layers();
+
+        for (layer, new_layer) in layers.iter().zip(new_layers.iter()) {
+            let links = layer.get_links_map();
+            let new_links = new_layer.get_links_map();
+
+            for (point_id, queue) in links.iter() {
+                let new_point_id = point_ids[point_id];
+                let new_queue_vec = new_links[&new_point_id].to_vec();
+                let queue_vec = queue.to_vec();
+                for ((neighbor_id, distance), (new_neighbor_id, new_distance)) in
+                    queue_vec.iter().zip(new_queue_vec)
+                {
+                    assert_eq!(point_ids[neighbor_id], new_neighbor_id);
+                    assert_eq!(distances[distance], new_distance);
+                }
+            }
+        }
     }
 }

--- a/src/graph_store/graph_mem.rs
+++ b/src/graph_store/graph_mem.rs
@@ -18,6 +18,10 @@ impl<V: VectorStore> GraphMem<V> {
             layers: vec![],
         }
     }
+
+    pub fn get_layers(&self) -> Vec<Layer<V>> {
+        self.layers.clone()
+    }
 }
 
 // Plain converter for a Graph structure that has different distance ref and vector ref types.

--- a/src/graph_store/graph_mem.rs
+++ b/src/graph_store/graph_mem.rs
@@ -116,4 +116,8 @@ impl<V: VectorStore> Layer<V> {
     fn set_links(&mut self, from: V::VectorRef, links: FurthestQueueV<V>) {
         self.links.insert(from, links);
     }
+
+    pub fn get_links_map(&self) -> &HashMap<V::VectorRef, FurthestQueueV<V>> {
+        &self.links
+    }
 }

--- a/src/hnsw_db/queue.rs
+++ b/src/hnsw_db/queue.rs
@@ -65,13 +65,15 @@ impl<Vector: Clone, Distance: Clone> FurthestQueue<Vector, Distance> {
     }
 
     // Assumes that distance map doesn't change the distance metric
-    pub fn map<V>(
+    pub fn map<V, F1, F2>(
         self,
-        vector_map: fn(Vector) -> V::VectorRef,
-        distance_map: fn(Distance) -> V::DistanceRef,
+        vector_map: F1,
+        distance_map: F2,
     ) -> FurthestQueue<V::VectorRef, V::DistanceRef>
     where
         V: VectorStore,
+        F1: Fn(Vector) -> V::VectorRef,
+        F2: Fn(Distance) -> V::DistanceRef,
     {
         let queue: Vec<(V::VectorRef, V::DistanceRef)> = self
             .queue

--- a/src/hnsw_db/queue.rs
+++ b/src/hnsw_db/queue.rs
@@ -63,6 +63,24 @@ impl<Vector: Clone, Distance: Clone> FurthestQueue<Vector, Distance> {
     pub fn trim_to_k_nearest(&mut self, k: usize) {
         self.queue.truncate(k);
     }
+
+    // Assumes that distance map doesn't change the distance metric
+    pub fn map<V>(
+        self,
+        vector_map: fn(Vector) -> V::VectorRef,
+        distance_map: fn(Distance) -> V::DistanceRef,
+    ) -> FurthestQueue<V::VectorRef, V::DistanceRef>
+    where
+        V: VectorStore,
+    {
+        let queue: Vec<(V::VectorRef, V::DistanceRef)> = self
+            .queue
+            .iter()
+            .cloned()
+            .map(|(v, d)| (vector_map(v), distance_map(d)))
+            .collect();
+        FurthestQueue::from_ascending_vec(queue)
+    }
 }
 
 // Utility implementations.

--- a/src/hnsw_db/queue.rs
+++ b/src/hnsw_db/queue.rs
@@ -83,6 +83,10 @@ impl<Vector: Clone, Distance: Clone> FurthestQueue<Vector, Distance> {
             .collect();
         FurthestQueue::from_ascending_vec(queue)
     }
+
+    pub fn as_vec_ref(&self) -> &[(Vector, Distance)] {
+        &self.queue
+    }
 }
 
 // Utility implementations.


### PR DESCRIPTION
Some helpers are added to convert from plaintext to secret shared graphs. `from_another` is updated to support closures instead of functions.