### PR TITLE
Feat / Add support for variable ef values

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,7 @@ dependencies = [
  "futures",
  "rand",
  "rand_core",
+ "rand_distr",
  "serde",
  "serde_json",
  "sqlx",
@@ -1126,6 +1127,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1.38", features = ["full"] }
 tokio-stream = "0.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
+rand_distr = "0.4.3"
 
 [features]
 db_dependent = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ sqlx = { version = "~0.8", features = [
 ] }
 tokio = { version = "1.38", features = ["full"] }
 tokio-stream = "0.1"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 
 [features]

--- a/src/graph_store/graph_mem.rs
+++ b/src/graph_store/graph_mem.rs
@@ -220,16 +220,17 @@ mod tests {
 
         for raw_query in 0..10 {
             let query = vector_store.prepare_query(raw_query);
+            let insertion_layer = searcher.select_layer(&mut rng);
             let neighbors = searcher
-                .search_to_insert(&mut vector_store, &mut graph_store, &query)
+                .search_to_insert(&mut vector_store, &mut graph_store, &query, insertion_layer)
                 .await;
             let inserted = vector_store.insert(&query).await;
             searcher
                 .insert_from_search_results(
                     &mut vector_store,
                     &mut graph_store,
-                    &mut rng,
                     inserted,
+                    insertion_layer,
                     neighbors,
                 )
                 .await;
@@ -256,16 +257,17 @@ mod tests {
 
         for raw_query in 0..10 {
             let query = vector_store.prepare_query(raw_query);
+            let insertion_layer = searcher.select_layer(&mut rng);
             let neighbors = searcher
-                .search_to_insert(&mut vector_store, &mut graph_store, &query)
+                .search_to_insert(&mut vector_store, &mut graph_store, &query, insertion_layer)
                 .await;
             let inserted = vector_store.insert(&query).await;
             searcher
                 .insert_from_search_results(
                     &mut vector_store,
                     &mut graph_store,
-                    &mut rng,
                     inserted,
+                    insertion_layer,
                     neighbors,
                 )
                 .await;

--- a/src/graph_store/graph_mem.rs
+++ b/src/graph_store/graph_mem.rs
@@ -3,9 +3,10 @@ use crate::{
     hnsw_db::{FurthestQueue, FurthestQueueV},
     VectorStore,
 };
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Default, Clone, PartialEq, Eq, Debug)]
+#[derive(Default, Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct GraphMem<V: VectorStore> {
     entry_point: Option<EntryPoint<V::VectorRef>>,
     layers: Vec<Layer<V>>,
@@ -106,7 +107,7 @@ impl<V: VectorStore> GraphStore<V> for GraphMem<V> {
     }
 }
 
-#[derive(PartialEq, Eq, Default, Clone, Debug)]
+#[derive(PartialEq, Eq, Default, Clone, Debug, Serialize, Deserialize)]
 pub struct Layer<V: VectorStore> {
     /// Map a base vector to its neighbors, including the distance base-neighbor.
     links: HashMap<V::VectorRef, FurthestQueueV<V>>,

--- a/src/graph_store/graph_pg.rs
+++ b/src/graph_store/graph_pg.rs
@@ -289,8 +289,9 @@ mod tests {
 
         // Insert the codes.
         for query in queries.iter() {
+            let insertion_layer = db.select_layer(rng);
             let neighbors = db
-                .search_to_insert(vector_store, graph.deref_mut(), query)
+                .search_to_insert(vector_store, graph.deref_mut(), query, insertion_layer)
                 .await;
             assert!(!db.is_match(vector_store, &neighbors).await);
             // Insert the new vector into the store.
@@ -298,8 +299,8 @@ mod tests {
             db.insert_from_search_results(
                 vector_store,
                 graph.deref_mut(),
-                rng,
                 inserted,
+                insertion_layer,
                 neighbors,
             )
             .await;
@@ -307,10 +308,8 @@ mod tests {
 
         // Search for the same codes and find matches.
         for query in queries.iter() {
-            let neighbors = db
-                .search_to_insert(vector_store, graph.deref_mut(), query)
-                .await;
-            assert!(db.is_match(vector_store, &neighbors).await);
+            let neighbors = db.search(vector_store, graph.deref_mut(), query, 1).await;
+            assert!(db.is_match(vector_store, &[neighbors]).await);
         }
 
         graph.cleanup().await.unwrap();

--- a/src/hnsw_db.rs
+++ b/src/hnsw_db.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 mod queue;
 pub use queue::{FurthestQueue, FurthestQueueV, NearestQueue, NearestQueueV};
 use rand::{Rng, RngCore};
+use serde::{Deserialize, Serialize};
 pub mod coroutine;
 
 use crate::{graph_store::EntryPoint, GraphStore, VectorStore};
@@ -11,7 +12,7 @@ use crate::{graph_store::EntryPoint, GraphStore, VectorStore};
 ///
 /// Operations on vectors are delegated to a VectorStore.
 /// Operations on the graph are delegate to a GraphStore.
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 #[allow(non_snake_case)]
 pub struct HawkSearcher {
     ef: usize,

--- a/src/hnsw_db.rs
+++ b/src/hnsw_db.rs
@@ -389,18 +389,26 @@ mod tests {
         // Insert the codes.
         for query in queries.iter() {
             let insertion_layer = db.select_layer(rng);
-            let neighbors = db.search_to_insert(vector_store, graph_store, query, insertion_layer).await;
+            let neighbors = db
+                .search_to_insert(vector_store, graph_store, query, insertion_layer)
+                .await;
             assert!(!db.is_match(vector_store, &neighbors).await);
             // Insert the new vector into the store.
             let inserted = vector_store.insert(query).await;
-            db.insert_from_search_results(vector_store, graph_store, inserted, insertion_layer, neighbors)
-                .await;
+            db.insert_from_search_results(
+                vector_store,
+                graph_store,
+                inserted,
+                insertion_layer,
+                neighbors,
+            )
+            .await;
         }
 
         // Search for the same codes and find matches.
         for query in queries.iter() {
             let neighbors = db.search(vector_store, graph_store, query, 1).await;
-            assert!(db.is_match(vector_store, &vec![neighbors]).await);
+            assert!(db.is_match(vector_store, &[neighbors]).await);
         }
     }
 }

--- a/src/hnsw_db.rs
+++ b/src/hnsw_db.rs
@@ -15,7 +15,7 @@ const N_PARAM_LAYERS: usize = 5;
 
 #[allow(non_snake_case)]
 #[derive(PartialEq, Clone, Serialize, Deserialize)]
-pub struct Params {
+pub struct HawkerParams {
     pub M: [usize; N_PARAM_LAYERS], // number of neighbors for insertion
     pub M_max: [usize; N_PARAM_LAYERS], // maximum number of neighbors
     pub ef_constr_search: [usize; N_PARAM_LAYERS], // ef_constr for search layers
@@ -25,12 +25,12 @@ pub struct Params {
 }
 
 #[allow(non_snake_case, clippy::too_many_arguments)]
-impl Params {
+impl HawkerParams {
     /// Construct a `Params` object corresponding to parameter configuration
     /// providing the functionality described in the original HNSW paper:
     /// - ef_construction exploration factor used for insertion layers
     /// - ef_search exploration factor used for layer 0 in search
-    /// - Higher layers in both insertion and search use exploration factor 1,
+    /// - higher layers in both insertion and search use exploration factor 1,
     ///   representing simple greedy search
     /// - vertex degrees bounded by M_max = M in positive layer graphs
     /// - vertex degrees bounded by M_max0 = 2*M in layer 0 graph
@@ -122,8 +122,10 @@ impl Params {
     }
 
     #[inline(always)]
+    /// Select value at index `lc` from the input fixed-size array, or the last
+    /// index of this array if `lc` is larger than the array size.
     fn get_val(arr: &[usize; N_PARAM_LAYERS], lc: usize) -> usize {
-        *arr.get(lc).unwrap_or_else(|| arr.last().unwrap())
+        arr[lc.min(N_PARAM_LAYERS - 1)]
     }
 }
 
@@ -133,7 +135,7 @@ impl Params {
 /// Operations on the graph are delegate to a GraphStore.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct HawkSearcher {
-    pub params: Params,
+    pub params: HawkerParams,
 }
 
 // TODO remove default value; this varies too much between applications
@@ -141,7 +143,7 @@ pub struct HawkSearcher {
 impl Default for HawkSearcher {
     fn default() -> Self {
         HawkSearcher {
-            params: Params::new(64, 32, 32),
+            params: HawkerParams::new(64, 32, 32),
         }
     }
 }

--- a/src/hnsw_db/coroutine.rs
+++ b/src/hnsw_db/coroutine.rs
@@ -30,8 +30,9 @@ where
         let hawk = HawkSearcher::default();
         let vector_store = &mut OpsCollector { ops: tx.clone() };
         let graph_store = &mut OpsCollector { ops: tx.clone() };
+        // TODO insertion layer is hardcoded here, need to handle correctly
         let result = hawk
-            .search_to_insert(vector_store, graph_store, &query)
+            .search_to_insert(vector_store, graph_store, &query, 0)
             .await;
         tx.send(Op::SearchResult { query, result }).await.unwrap();
     });


### PR DESCRIPTION
Previously the HNSW implementation used a fixed value of `ef` for all layer search operations, including both search and insertion, and uniformly for all layers.  In this PR, a new `Params` struct is implemented which keeps track of parameter values individually for a small number of layers (0 through 4 currently), and parameters for any higher layers are chosen as the parameter values from the highest specified layer.

To support different `ef` values for insertion at "layers in which the query will be inserted" and "layers in which the query will not be inserted", the `HawkSearcher` interface needed to be modified: `search_to_insert` now takes an insertion layer as a parameter, so this needs to be generated externally prior to calling `search_to_insert`, rather than being generated inside `insert_from_search_results` using an `Rng` input.  Additionally, an extra `search` function has been implemented which conducts a search and only returns the layer 0 k-nearest neighbors using the search `ef` parameters for layer search rather than the insertion `ef` parameters.