### PR TITLE
Move `search_sorted` utility function from `VectorStore` trait to `queue.rs`

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -51,26 +51,6 @@ pub trait VectorStore: Clone + Debug {
         distance2: &Self::DistanceRef,
     ) -> bool;
 
-    /// Find the insertion index for a target distance to maintain order in a list of ascending distances.
-    async fn search_sorted(
-        &mut self,
-        distances: &[Self::DistanceRef],
-        target: &Self::DistanceRef,
-    ) -> usize {
-        let mut left = 0;
-        let mut right = distances.len();
-
-        while left < right {
-            let mid = left + (right - left) / 2;
-
-            match self.less_than(&distances[mid], target).await {
-                true => left = mid + 1,
-                false => right = mid,
-            }
-        }
-        left
-    }
-
     // Batch variants.
 
     /// Persist a batch of queries as new vectors in the store, and return references to them.


### PR DESCRIPTION
Previously the `VectorStore` trait included a function `search_sorted` which provides a default implementation of a basic binary search on a sorted list of vector ids.  This PR migrates the function from the trait definition to the priority queue implementations in `queue.rs`, which seems to be a more natural fit and is the only place the function call is currently used.